### PR TITLE
textrules Rename `Rule` -> `SyntaxRule`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ The lint rule is defined as `SyntaxRule` trait.
 pub struct SamplePlugin;
 
 impl SyntaxRule for SamplePlugin {
-    fn check(&self, _syntax_tree: &SyntaxTree, node: &RefNode) -> RuleResult {
+    fn check(&self, _syntax_tree: &SyntaxTree, node: &RefNode) -> SyntaxRuleResult {
         match node {
-            RefNode::InitialConstruct(_) => RuleResult::Fail,
-            _ => RuleResult::Pass,
+            RefNode::InitialConstruct(_) => SyntaxRuleResult::Fail,
+            _ => SyntaxRuleResult::Pass,
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -12,22 +12,22 @@ svlint plugin is a shared library. So crate-type of `Cargo.toml` must be `cdylib
 crate-type = ["cdylib"]
 ```
 
-All plugin must have `get_plugin` function to generate `Rule`.
+All plugin must have `get_plugin` function to generate `SyntaxRule`.
 
 ```
 #[no_mangle]
-pub extern "C" fn get_plugin() -> *mut dyn Rule {
+pub extern "C" fn get_plugin() -> *mut dyn SyntaxRule {
     let boxed = Box::new(SamplePlugin {});
     Box::into_raw(boxed)
 }
 ```
 
-The lint rule is defined as `Rule` trait.
+The lint rule is defined as `SyntaxRule` trait.
 
 ```
 pub struct SamplePlugin;
 
-impl Rule for SamplePlugin {
+impl SyntaxRule for SamplePlugin {
     fn check(&self, _syntax_tree: &SyntaxTree, node: &RefNode) -> RuleResult {
         match node {
             RefNode::InitialConstruct(_) => RuleResult::Fail,
@@ -49,7 +49,7 @@ impl Rule for SamplePlugin {
 }
 ```
 
-`Rule` must implement `check`, `name`, `hint` and `reason`.
+`SyntaxRule` must implement `check`, `name`, `hint` and `reason`.
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,16 @@
 use sv_parser::{NodeEvent, RefNode, SyntaxTree};
 use svlint::config::ConfigOption;
-use svlint::linter::{Rule, RuleResult};
+use svlint::linter::{SyntaxRule, RuleResult};
 
 #[no_mangle]
-pub extern "C" fn get_plugin() -> *mut dyn Rule {
+pub extern "C" fn get_plugin() -> *mut dyn SyntaxRule {
     let boxed = Box::new(SamplePlugin {});
     Box::into_raw(boxed)
 }
 
 pub struct SamplePlugin;
 
-impl Rule for SamplePlugin {
+impl SyntaxRule for SamplePlugin {
     fn check(
         &mut self,
         _syntax_tree: &SyntaxTree,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use sv_parser::{NodeEvent, RefNode, SyntaxTree};
 use svlint::config::ConfigOption;
-use svlint::linter::{SyntaxRule, RuleResult};
+use svlint::linter::{SyntaxRule, SyntaxRuleResult};
 
 #[no_mangle]
 pub extern "C" fn get_plugin() -> *mut dyn SyntaxRule {
@@ -16,10 +16,10 @@ impl SyntaxRule for SamplePlugin {
         _syntax_tree: &SyntaxTree,
         event: &NodeEvent,
         _config: &ConfigOption,
-    ) -> RuleResult {
+    ) -> SyntaxRuleResult {
         match event {
-            NodeEvent::Enter(RefNode::InitialConstruct(_)) => RuleResult::Fail,
-            _ => RuleResult::Pass,
+            NodeEvent::Enter(RefNode::InitialConstruct(_)) => SyntaxRuleResult::Fail,
+            _ => SyntaxRuleResult::Pass,
         }
     }
 


### PR DESCRIPTION
Update to match new (future) textrules feature in svlint <https://github.com/dalance/svlint/pull/247>

See also:

- Discussion on plan for textrules functionality <https://github.com/dalance/svlint/issues/237>
- Discussion on this moving <https://github.com/dalance/svlint/issues/244>
- Matching draft PR on svlint <https://github.com/dalance/svlint/pull/246>