### PR TITLE
Updated example for Vec of Rule

### DIFF
--- a/src/another_plugin.rs
+++ b/src/another_plugin.rs
@@ -1,0 +1,32 @@
+use sv_parser::{NodeEvent, RefNode, SyntaxTree};
+use svlint::config::ConfigOption;
+use svlint::linter::{Rule, RuleResult};
+
+#[derive(Default)]
+pub struct AnotherPlugin;
+
+impl Rule for AnotherPlugin {
+    fn check(
+        &mut self,
+        _syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _config: &ConfigOption,
+    ) -> RuleResult {
+        match event {
+            NodeEvent::Enter(RefNode::DisableStatementFork(_)) => RuleResult::Fail,
+            _ => RuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("another_plugin")
+    }
+
+    fn hint(&self, _config: &ConfigOption) -> String {
+        String::from("`disable fork` is forbidden")
+    }
+
+    fn reason(&self) -> String {
+        String::from("this is another plugin")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,37 +1,30 @@
-use sv_parser::{NodeEvent, RefNode, SyntaxTree};
-use svlint::config::ConfigOption;
-use svlint::linter::{Rule, RuleResult};
+mod sample_plugin;
+mod another_plugin;
+
+use svlint::linter::Rule;
+use crate::{
+    sample_plugin::SamplePlugin,
+    another_plugin::AnotherPlugin,
+};
 
 #[no_mangle]
-pub extern "C" fn get_plugin() -> *mut dyn Rule {
-    let boxed = Box::new(SamplePlugin {});
-    Box::into_raw(boxed)
+pub extern "C" fn get_plugin() -> Vec<*mut dyn Rule> {
+    combine_rules!(
+        SamplePlugin,
+        AnotherPlugin,
+    )
 }
 
-pub struct SamplePlugin;
-
-impl Rule for SamplePlugin {
-    fn check(
-        &mut self,
-        _syntax_tree: &SyntaxTree,
-        event: &NodeEvent,
-        _config: &ConfigOption,
-    ) -> RuleResult {
-        match event {
-            NodeEvent::Enter(RefNode::InitialConstruct(_)) => RuleResult::Fail,
-            _ => RuleResult::Pass,
+#[macro_export]
+macro_rules! combine_rules {
+    ( $( $x:ty ),* $(,)? ) => {
+        {
+            let mut vec: Vec<*mut dyn Rule> = Vec::new();
+            $(
+                let boxed = Box::<$x>::default();
+                vec.push(Box::into_raw(boxed));
+            )*
+            vec
         }
-    }
-
-    fn name(&self) -> String {
-        String::from("sample_plugin")
-    }
-
-    fn hint(&self, _config: &ConfigOption) -> String {
-        String::from("`initial` is forbidden")
-    }
-
-    fn reason(&self) -> String {
-        String::from("this is a sample plugin")
-    }
+    };
 }

--- a/src/sample_plugin.rs
+++ b/src/sample_plugin.rs
@@ -1,0 +1,32 @@
+use sv_parser::{NodeEvent, RefNode, SyntaxTree};
+use svlint::config::ConfigOption;
+use svlint::linter::{Rule, RuleResult};
+
+#[derive(Default)]
+pub struct SamplePlugin;
+
+impl Rule for SamplePlugin {
+    fn check(
+        &mut self,
+        _syntax_tree: &SyntaxTree,
+        event: &NodeEvent,
+        _config: &ConfigOption,
+    ) -> RuleResult {
+        match event {
+            NodeEvent::Enter(RefNode::InitialConstruct(_)) => RuleResult::Fail,
+            _ => RuleResult::Pass,
+        }
+    }
+
+    fn name(&self) -> String {
+        String::from("sample_plugin")
+    }
+
+    fn hint(&self, _config: &ConfigOption) -> String {
+        String::from("`initial` is forbidden")
+    }
+
+    fn reason(&self) -> String {
+        String::from("this is a sample plugin")
+    }
+}


### PR DESCRIPTION
This PR is meant to match the changes brought by dalance/svlint#251 which would let a plugin return a Vec of Rules instead of a single Rule.