### PR TITLE
Setup basic CI flow

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,37 @@
+name: Regression
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        rust: [stable]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: ${{ matrix.rust }}
+      - name: BUILDENV
+        shell: bash
+        run: |
+          rm -f BUILDENV
+          rustup --version >> BUILDENV
+          cargo --version >> BUILDENV
+          rustc --version >> BUILDENV
+          cat BUILDENV
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('BUILDENV', '**/Cargo.lock') }}
+      - run: cargo test

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ crate-type = ["cdylib"]
 All plugin must have `get_plugin` function to generate `Rule`.
 
 ```
+#[allow(improper_ctypes_definitions)]
 #[no_mangle]
 pub extern "C" fn get_plugin() -> *mut dyn Rule {
     let boxed = Box::new(SamplePlugin {});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use sv_parser::{NodeEvent, RefNode, SyntaxTree};
 use svlint::config::ConfigOption;
 use svlint::linter::{Rule, RuleResult};
 
+#[allow(improper_ctypes_definitions)]
 #[no_mangle]
 pub extern "C" fn get_plugin() -> *mut dyn Rule {
     let boxed = Box::new(SamplePlugin {});


### PR DESCRIPTION
- Copy regression.yml from svlint to run `cargo test`.
- There are currently no tests, but this does attempt a `cargo build`,
  which is sufficient to detect API breakage between svlint and svlint-plugin-sample.
- As per https://github.com/dalance/svlint/issues/253